### PR TITLE
Adds Firefox extension compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ just clone this repo and load unpacked extension. (you have to enable developer 
 ![unpacked](screenshots/unpacked.png)  
 you can also install this in firefox or any browser, just set the ``index.html`` to your new tab page / create an addon which replaces the new tab page with this ``index.html``
 
+### installation (firefox based browsers)
+First, download this repository as a .zip file.
+
+In Firefox open Settings > Extension & Themes. 
+
+Click on the settings icon at the top and choose "Install Add-on from file..." and choose the .zip file. Firefox will warn you that the extension is unsafe (due to it being unverified), but it is safe to use.
+
 ### custom images
 if you want a custom image, put it in the ``img`` folder.
 the image should be either a standard portrait image (good for left image) or a wide slice/landscape image (good for top image).   

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,35 @@
 {
-  "chrome_url_overrides": {
-    "newtab": "./index.html"
-  },
-  "description": "Overrides the browsers newtab page with a rosebox minimal-startpage.",
-  "icons": {
-    "64": "img/icon64.png"
-  },
   "manifest_version": 3,
   "name": "minimal-startpage",
   "short_name": "minimal-startpage",
   "version": "2.0",
+  "description": "Overrides the browsers newtab page with a rosebox minimal-startpage.",
+  "icons": {
+    "64": "img/icon64.png"
+  },
+
   "author": "kraxen72",
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  "content_scripts": [
+    {
+      "matches": ["*://*.mozilla.org/*"],
+      "js": [
+        "main.js",
+        "settings.js",
+        "circle-assign.js",
+        "observe.js",
+        "sortable.js",
+        "tinydate.js"
+      ],
+      "css": ["style.css", "layout.css"]
+    }
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "minimal@example.com"
+    }
+  },
+  "chrome_url_overrides": {
+    "newtab": "./index.html"
+  }
 }


### PR DESCRIPTION
I added a few elements to comply with Mozilla's extension policies.

To install the extension download the repo as a zip file, in Firefox open Settings > Extension & Themes, click on the settings icon and choose "Install extension from file...". The extension will appear as unsafe (due to it being unverified), but it will work.
